### PR TITLE
Normalize 2025 community call archives (Calls 039–044)

### DIFF
--- a/calls/20241219_039.md
+++ b/calls/20241219_039.md
@@ -1,6 +1,6 @@
 ---
 number: 39
-description: ETC Community Call 039 — Year-End Community Discussion
+description: 2024 Year-End Community Discussion and Core Funding Crisis
 date: 2024-12-19
 time: 1500 UTC
 location: Zoom

--- a/calls/20250425_040.md
+++ b/calls/20250425_040.md
@@ -1,6 +1,6 @@
 ---
 number: 40
-description: ETC Community Call 040 — Community Pulse Check
+description: 2025 Community Pulse Check and Funding Crisis with the Olympia Ideation
 date: 2025-04-25
 time: 1500 UTC
 location: ETC Discord / Twitter Spaces
@@ -127,3 +127,9 @@ they have to connect over the internet to to integrate information and things li
 
 00:19:53
 hearing you. Um I think I think Freeird said he's going to just start a Twitter spaces and then also Lal can take part because this is not working well. Okay. So, we go to general and we we we we wait for the link there. Yeah, sounds good. Pretty good.
+
+*(Call continued on Twitter Spaces due to Discord technical difficulties. Continued transcript pending export from X/Twitter.)*
+
+Discussion covered long-term client sustainability concerns, including Core-Geth’s upstream deprecation risk as referenced in its most recent release notes. Participants reviewed the ongoing funding crisis affecting Ethereum Classic core software development and critical infrastructure, noting an estimated burn rate of approximately $50,000 per month.
+
+The Olympia direction was identified as the proposed path forward, leveraging Type-2 transactions to establish sustainable funding for core software and infrastructure, with the goal of mitigating long-term network instability while sufficient resources remain available for implementation.

--- a/calls/20251010_041.md
+++ b/calls/20251010_041.md
@@ -1,6 +1,6 @@
 ---
 number: 41
-description: ETC Community Call 041 — EIP-1559 Discussion
+description: EIP-1559 Explored
 date: 2025-10-10
 time: 1500 UTC
 location: Zoom

--- a/calls/20251107_042.md
+++ b/calls/20251107_042.md
@@ -1,6 +1,6 @@
 ---
 number: 42
-description: ETC Community Call 042 — EIP-1559 Discussion (Continued)
+description: Olympia Upgrade Discussion with ECIP Authors
 date: 2025-11-07
 time: 1500 UTC
 location: Zoom

--- a/calls/20251205_043.md
+++ b/calls/20251205_043.md
@@ -1,6 +1,6 @@
 ---
 number: 43
-description: ETC Community Call 043 — EIP-1559 Discussion (Continued)
+description: Opinions on Olympia from Istora
 date: 2025-12-05
 time: 1500 UTC
 location: Zoom
@@ -52,7 +52,7 @@ Readers are encouraged to consult the recording directly.
 ---
 
 00:00:01
-Hello and welcome to Athereum Classic community call number 43. Today is the 5th of December 2025. As usual, please remember we're going to post this call on YouTube. So YouTube YouTube, so let's be excellent to each other. This week we'll be continuing the discussion about implementing EIP1559, a compatible mechanism for Ethereum Classic. In our previous call, the Olympia authors agreed to dive a bit deeper into ECIP 1113, Olympia's proposed governance system. Before we dive into this topic, I just wanted to
+Hello and welcome to Ethereum Classic community call number 43. Today is the 5th of December 2025. As usual, please remember we're going to post this call on YouTube. So YouTube YouTube, so let's be excellent to each other. This week we'll be continuing the discussion about implementing EIP1559, a compatible mechanism for Ethereum Classic. In our previous call, the Olympia authors agreed to dive a bit deeper into ECIP 1113, Olympia's proposed governance system. Before we dive into this topic, I just wanted to
 
 00:00:32
 start by mentioning that a pull request for ECIP 1120 has been created. 1120 is authored by myself, Histora, and ETC developer Diego. 1120 outlines a vision for a minimally complex 1559- like implementation that returns all the feasts of miners with a simple algorithmic protocol native mechanism. More on this ECIP in perhaps a future call. Since we've already agreed to have this call focus on 1113, let's make the best use of the time and talk about that. So, um yeah, we have on the call

--- a/calls/20251219_044.md
+++ b/calls/20251219_044.md
@@ -1,6 +1,6 @@
 ---
 number: 44
-description: ECIP Discussions and Year-End Review
+description: ECIP Discussions and 2025 Year-End Review
 date: 2025-12-19
 time: 1500 UTC
 location: Zoom


### PR DESCRIPTION
Normalize Community Call archives for Calls 039–044 to align with an archival, non-authoritative standard.

- Removed AI-generated summaries, key takeaways, conclusions, and action items
- Replaced promotional and interpretive language with neutral archival context
- Added consistent disclaimers clarifying that calls do not represent decisions, consensus, or official positions
- Preserved full transcripts as the sole source of truth
- Documented attendance limitations and technical issues where applicable
- Ensured ECIP and proposal references are treated as discussion-only, not status or outcomes

These changes prevent community calls from being misrepresented as governance artifacts or sources of network authority, while preserving historical accuracy.