### PR TITLE
Add contextual disclaimer to site footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -74,5 +74,9 @@ import ETCLogo from "./ETCLogo.astro";
         </Link>
       </div>
     </div>
+    <!-- Archival disclaimer -->
+    <p class="mt-6 text-xs font-mono text-gray-500 text-center leading-relaxed">
+    Community call pages are archival records of informal community discussions and are not authoritative sources of network decisions or consensus. Transcripts are the sole source of truth for what was said during the call; summaries, titles, and layouts are non-authoritative and may change.
+    </p>
   </div>
 </footer>


### PR DESCRIPTION
Add a footer disclaimer providing additional context about ETC Community Call pages.

The disclaimer clarifies that community calls are informal discussions and that transcripts are the authoritative record of what was said. Summaries, titles, and layout elements are informational and may change.

This is a contextual clarification only and does not modify call content, metadata, transcripts, or site behavior.